### PR TITLE
List signed/unsigned documents, sign document

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,67 @@
+DROP TABLE IF EXISTS signatories;
+DROP TABLE IF EXISTS documents;
+DROP TABLE IF EXISTS employees;
+DROP TABLE IF EXISTS companies;
+DROP TABLE IF EXISTS document_templates;
+
+
+CREATE TABLE companies (
+    id             SERIAL PRIMARY KEY,
+    company_name   TEXT    NOT NULL UNIQUE
+);
+
+CREATE TABLE employees (
+    id             SERIAL PRIMARY KEY,
+    tin            TEXT    NOT NULL UNIQUE,
+    full_name      TEXT    NOT NULL,
+    password_hash  TEXT    NOT NULL,
+    job            TEXT    NOT NULL,
+    company_id     INTEGER NOT NULL
+        REFERENCES companies(id)
+        ON DELETE RESTRICT
+);
+
+CREATE TABLE document_templates (
+    id             SERIAL PRIMARY KEY,
+    structure      TEXT    NOT NULL,
+    title          TEXT    NOT NULL
+);
+
+CREATE TABLE documents (
+    id             SERIAL PRIMARY KEY,
+    template_id    INTEGER NOT NULL
+        REFERENCES document_templates(id)
+        ON DELETE RESTRICT,
+    content        TEXT    NOT NULL
+);
+
+CREATE TABLE signatories (
+    document_id    INTEGER NOT NULL
+        REFERENCES documents(id)
+        ON DELETE CASCADE,
+    employee_id    INTEGER NOT NULL
+        REFERENCES employees(id)
+        ON DELETE RESTRICT,
+    sign_status    BOOLEAN NOT NULL,
+    PRIMARY KEY (document_id, employee_id)
+);
+
+INSERT INTO companies(company_name) VALUES ('SSU');
+
+INSERT INTO employees(tin, full_name, password_hash, job, company_id)
+VALUES ('111-22-3333', 'Admin', '$2a$12$0hehvRZgk9/t8BKxaNAvWuAAs.q67WlsmJ79gN6mUNEogmv7DZfe2', 'Owner', 1);
+
+INSERT INTO employees(tin, full_name, password_hash, job, company_id)
+VALUES ('222-11-3333', 'User', '$2a$12$0hehvRZgk9/t8BKxaNAvWuAAs.q67WlsmJ79gN6mUNEogmv7DZfe2', 'Analyst', 1);
+
+INSERT INTO document_templates(structure, title) VALUES ('I, {{name1}}, hire person {{name2}} on the position {{job}}', 'Employment');
+INSERT INTO document_templates(structure, title) VALUES ('I, {{name1}}, sell {{sell_item}} to {{name2}} for {{amount}} USD', 'Sell Contract (USD)');
+INSERT INTO document_templates(structure, title) VALUES ('I, {{name1}}, authorize the use of {{share_item}} to {{name2}}', 'Sharing');
+
+INSERT INTO documents(template_id, content) VALUES (1, '{"name1":"Admin","name2":"User","job":"Analyst"}');
+INSERT INTO documents(template_id, content) VALUES (2, '{"name1":"User","name2":"Admin","sell_item":"BMW X5","amount":"20000"}');
+
+INSERT INTO signatories(document_id, employee_id, sign_status) VALUES (1, 1, TRUE);
+INSERT INTO signatories(document_id, employee_id, sign_status) VALUES (1, 2, TRUE);
+INSERT INTO signatories(document_id, employee_id, sign_status) VALUES (2, 1, TRUE);
+INSERT INTO signatories(document_id, employee_id, sign_status) VALUES (2, 2, FALSE);

--- a/src/ConsoleDriver.java
+++ b/src/ConsoleDriver.java
@@ -1,7 +1,4 @@
-import dao.CompanyDAO;
-import dao.DocumentDAO;
-import dao.DocumentTemplateDAO;
-import dao.EmployeeDAO;
+import dao.*;
 import entities.Company;
 import entities.Document;
 import entities.DocumentTemplate;
@@ -95,7 +92,8 @@ public class ConsoleDriver {
             System.out.println("1) Create new document");
             System.out.println("2) List signed documents");
             System.out.println("3) Show unsigned documents");
-            System.out.println("4) Log out\n");
+            System.out.println("4) Sign document");
+            System.out.println("5) Log out\n");
 
             action = EmployeeMenuAction.values()[askIntegerValue("Action", 1, actionsLength) - 1];
             switch (action) {
@@ -104,8 +102,9 @@ public class ConsoleDriver {
                     System.out.println("\n----- Create new document -----");
                     createDocument(emp);
                 }
-                case EmployeeMenuAction.LIST_DOCS -> System.out.println("List my signed documents");
-                case EmployeeMenuAction.SHOW_UNSIGNED_DOCS -> System.out.println("Show unsigned documents");
+                case EmployeeMenuAction.LIST_DOCS -> showDocumentsList(emp, true);
+                case EmployeeMenuAction.SHOW_UNSIGNED_DOCS -> showDocumentsList(emp, false);
+                case EmployeeMenuAction.SIGN_DOC -> signDocumentAction(emp);
                 case EmployeeMenuAction.LOG_OUT -> {
                     System.out.println("Logging out...");
                 }
@@ -188,12 +187,12 @@ public class ConsoleDriver {
         System.out.println("\n----- Employee login -----");
 
         // NOTE: uncomment for real using
-        /*String tin = askTINValue();
+        String tin = askTINValue();
         String password = askStringValue("Enter password", false);
-        employee = employeeDAO.readByTINandPasswordHash(tin, password);*/
+        employee = employeeDAO.readByTINandPasswordHash(tin, password);
 
         // NOTE: test data
-        employee = employeeDAO.readByTINandPasswordHash("000-00-0000", "test");
+//        employee = employeeDAO.readByTINandPasswordHash("000-00-0000", "test");
 
         return employee;
     }
@@ -260,5 +259,83 @@ public class ConsoleDriver {
         } while (action != DocumentCreationMenuAction.LEAVE);
 
         return null;
+    }
+
+    private static void signDocumentAction(Employee emp) {
+        DocumentDAO documentDAO = new DocumentDAO();
+
+        int answer = askIntegerValue("Enter document ID (0 for leave)");
+        if (answer == 0) {
+            System.out.println("Canceled!");
+            return;
+        }
+
+        Document document = documentDAO.readById(answer);
+        if (document == null) {
+            System.out.println("There is no document with this ID");
+            return;
+        }
+
+        boolean isSignatory = false;
+        for (Signatory signatory : document.getSignatories()) {
+            if (signatory.getEmployee().getId().equals(emp.getId())) {
+                if (!signatory.isSigned()) {
+                    isSignatory = true;
+                }
+                break;
+            }
+        }
+
+        if (!isSignatory) {
+            System.out.println("Your signature is not needed on this document or you already signed this document");
+            return;
+        }
+
+        printDocumentOverview(emp, document);
+        String confirmation = askStringValue(
+                "Are you sure that you want to sign this document (y - YES, other - NO)", false);
+        if (!confirmation.toLowerCase().trim().equals("y")) {
+            System.out.println("Canceled!");
+        }
+
+        document.signByEmployee(emp);
+        documentDAO.update(document);
+
+        System.out.println("Document has been successfully signed!");
+    }
+
+    private static void showDocumentsList(Employee employee, boolean signed) {
+        DocumentDAO documentDAO = new DocumentDAO();
+        EmployeeDAO employeeDAO = new EmployeeDAO();
+
+        List<Document> documents = documentDAO.listBySignatoryEmployeeId(employee.getId(), signed);
+
+        for (Document doc : documents) {
+            printDocumentOverview(employee, doc);
+        }
+    }
+
+    private static List<String> getSignatoriesRepresentations(Employee currEmployee, Document doc) {
+        List<String> signatoriesStatuses = new ArrayList<>();
+        for (Signatory signatory : doc.getSignatories()) {
+            Employee signatoryEmp = signatory.getEmployee();
+            String signatorySubstr = signatoryEmp.getFullName() + " (TIN: " + signatoryEmp.getTIN()
+                    + (Objects.equals(signatoryEmp.getId(), currEmployee.getId()) ? ", you) " : ") ")
+                    + (signatory.isSigned() ? "(signed)" : "(unsigned)");
+
+            signatoriesStatuses.add(signatorySubstr);
+        }
+        return signatoriesStatuses;
+    }
+
+    private static void printDocumentOverview(Employee currEmployee, Document doc) {
+        List<String> signatoriesStatuses = getSignatoriesRepresentations(currEmployee, doc);
+
+        System.out.println("--- DOC (ID: " + doc.getId() + ") ---");
+        System.out.println("TITLE:       " + doc.getTemplate().getTitle());
+        System.out.println("SIGNATORIES: " + String.join(", ", signatoriesStatuses));
+        System.out.println("IS VALID?:   " + (doc.isCompleted() ? "YES" : "NO"));
+        System.out.println("\nCONTENT:\n***\n" + doc.render() + "\n***");
+        System.out.println("--- DOC (ID: " + doc.getId() + ") ---\n");
     }
 }

--- a/src/dao/DocumentDAO.java
+++ b/src/dao/DocumentDAO.java
@@ -10,6 +10,7 @@ import exceptions.DocumentValidationException;
 import exceptions.IllegalIdException;
 
 import java.sql.*;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -69,7 +70,7 @@ public class DocumentDAO implements GenericDAO<Document> {
                 Map<String,String> content = mapper.readValue(json, new TypeReference<>(){});
                 List<Signatory> signatories = signatoryDAO.findByDocumentId(id);
 
-                return new Document(tpl, content, signatories);
+                return new Document(id, tpl, content, signatories);
             }
         } catch (SQLException e) {
             throw new RuntimeException("Error reading Document", e);
@@ -77,6 +78,46 @@ public class DocumentDAO implements GenericDAO<Document> {
             throw new RuntimeException("Invalid Document data", e);
         } catch (Exception e) {
             throw new RuntimeException("Deserialization error", e);
+        }
+    }
+
+    public List<Document> listBySignatoryEmployeeId(Integer employeeId, boolean signStatus) {
+        if (employeeId == null || employeeId < 1) {
+            throw new IllegalArgumentException("Document cannot be null");
+        }
+        String sql = "SELECT d.id, d.template_id, d.content FROM documents d " +
+                "JOIN signatories s ON s.document_id = d.id WHERE s.employee_id = ? AND sign_status = ?";
+
+        List<Document> documents = new ArrayList<>();
+
+        try (Connection conn = DBConnection.connect();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+
+            stmt.setInt(1, employeeId);
+            stmt.setBoolean(2, signStatus);
+
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    int documentId = rs.getInt("id");
+                    int tplId = rs.getInt("template_id");
+                    String json = rs.getString("content");
+
+                    DocumentTemplate tpl = templateDAO.readById(tplId);
+                    Map<String, String> content = mapper.readValue(json, new TypeReference<>() {});
+
+                    List<Signatory> signatories = signatoryDAO.findByDocumentId(documentId);
+
+                    Document doc = new Document(tpl, content, signatories);
+                    doc.setId(documentId);
+                    documents.add(doc);
+                }
+            }
+
+            return documents;
+        } catch (SQLException e) {
+            throw new RuntimeException("Error updating Document", e);
+        } catch (Exception e) {
+            throw new RuntimeException("Serialization error", e);
         }
     }
 

--- a/src/dao/EmployeeDAO.java
+++ b/src/dao/EmployeeDAO.java
@@ -44,7 +44,7 @@ public class EmployeeDAO implements GenericDAO<Employee> {
             throw new IllegalIdException();
         }
 
-        String sql = "SELECT id, tin, fullname, password_hash, job, company_id FROM employees WHERE id = ?";
+        String sql = "SELECT id, tin, full_name, password_hash, job, company_id FROM employees WHERE id = ?";
         try (Connection conn = DBConnection.connect();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
             stmt.setInt(1, id);
@@ -57,10 +57,10 @@ public class EmployeeDAO implements GenericDAO<Employee> {
             return new Employee(
                     rs.getInt("id"),
                     rs.getString("tin"),
-                    rs.getString("full_name"),
                     rs.getString("password_hash"),
+                    rs.getString("full_name"),
                     rs.getString("job"),
-                    new Company(companyDAO.readById(rs.getInt("id"))));
+                    new Company(companyDAO.readById(rs.getInt("company_id"))));
 
         } catch (SQLException e) {
             throw new RuntimeException(e);

--- a/src/entities/Document.java
+++ b/src/entities/Document.java
@@ -14,6 +14,27 @@ public class Document extends BaseEntity {
     private Map<String, String> content;
     private final List<Signatory> signatories;
 
+    public Document(Integer id, DocumentTemplate template, Map<String, String> content, List<Signatory> signatories)
+            throws DocumentValidationException {
+        if (id == null || id < 1) {
+            throw new DocumentValidationException("ID cannot be null or less than 1");
+        }
+        if (template == null) {
+            throw new DocumentValidationException("Template cannot be null");
+        }
+        if (content == null || content.isEmpty()) {
+            throw new DocumentValidationException("Content cannot be null or empty");
+        }
+        if (signatories == null || signatories.isEmpty()) {
+            throw new DocumentValidationException("Signatories cannot be null or empty");
+        }
+
+        this.id = id;
+        this.template = template;
+        this.fillContent(content);
+        this.signatories = signatories;
+    }
+
     public Document(DocumentTemplate template, Map<String, String> content, List<Signatory> signatories)
             throws DocumentValidationException {
         if (template == null) {
@@ -52,6 +73,17 @@ public class Document extends BaseEntity {
 
     public List<Signatory> getSignatories() {
         return signatories;
+    }
+
+    public boolean signByEmployee(Employee emp) {
+        for (Signatory signatory : signatories) {
+            if (signatory.getEmployee().getId().equals(emp.getId())) {
+                signatory.setSignStatus(true);
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public boolean isCompleted() {

--- a/src/menuAction/EmployeeMenuAction.java
+++ b/src/menuAction/EmployeeMenuAction.java
@@ -4,5 +4,6 @@ public enum EmployeeMenuAction {
     CREATE_DOC,
     LIST_DOCS,
     SHOW_UNSIGNED_DOCS,
+    SIGN_DOC,
     LOG_OUT
 }


### PR DESCRIPTION
1. Employee actions: List signed documents, show unsigned documents, (new action) sign document
2. Small fixes/extensions in DAO, entities
3. example of init.sql. Initialize PostgreSQL with it and, if you uncomment real "log in" interaction, you can use credentials:

TIN: `111-22-3333`, password: `123` | 2 signed documents
TIN: `222-11-3333`, password: `123` | 1 signed, 1 unsigned documents